### PR TITLE
Add search functionality to the conversation list

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
                 <span class="mdl-layout-title" id="toolbar-title">{{ $store.state.title }}</span>
                 <div id="toolbar_icons" >
                     <transition-group name="list">
-                    <button id="search-button" class="menu_icon refresh mdl-button mdl-button--icon mdl-js-button mdl-js-ripple-effect" tag="button" v-if="$route.name == 'conversations-list'" key="search" @click="openUrl('https://messenger.klinkerapps.com/search.html');">
+                    <button id="search-button" class="menu_icon refresh mdl-button mdl-button--icon mdl-js-button mdl-js-ripple-effect" tag="button" v-if="$route.name == 'conversations-list'" key="search" @click="dispatchMenuButton('search')">
                        <i class="material-icons">search</i>
                     </button>
                     <button id="add-button" class="menu_icon add mdl-button mdl-button--icon mdl-js-button mdl-js-ripple-effect" tag="button" v-if="$route.path.indexOf('thread') != -1" key="add" @click="$router.push('/compose');">

--- a/src/components/Conversations/Conversations.vue
+++ b/src/components/Conversations/Conversations.vue
@@ -4,6 +4,12 @@
         <!-- Spinner On load -->
         <spinner class="spinner" v-if="conversations.length == 0 && loading"></spinner>
 
+        <div id="quick_find" v-if="showSearch">
+           <div>
+             <input v-model="searchQuery" class="quick_find fixed_pos" type="text text_box" placeholder="Search conversations..." autocomplete="off" autocorrect="off" spellcheck="false">
+           </div>
+         </div>
+
         <!-- If no Messages -->
         <p class="empty-message" v-if="conversations.length == 0 && !loading">No Conversations</p>
 
@@ -37,6 +43,7 @@ export default {
         this.$store.state.msgbus.$on('removedConversation', this.fetchConversations);
         this.$store.state.msgbus.$on('refresh-btn', this.refresh);
         this.$store.state.msgbus.$on('newMargin', this.updateMargin);
+        this.$store.state.msgbus.$on('search-btn', this.toggleSearch);
 
         this.fetchConversations();
 
@@ -62,6 +69,7 @@ export default {
             this.$store.state.msgbus.$off('newMessage')
             this.$store.state.msgbus.$off('conversationRead')
             this.$store.state.msgbus.$off('refresh-btn');
+            this.$store.state.msgbus.$off('search-btn');
             this.$store.state.msgbus.$off('newMargin');
         }
     },
@@ -130,6 +138,7 @@ export default {
             this.loading = false;
             this.$store.commit('conversations', cache);
             this.conversations = updatedConversations;
+            this.unFilteredAllConversations = updatedConversations;
 
             if (!this.small) {
                 this.$store.commit("loading", false);
@@ -163,8 +172,8 @@ export default {
 
             // Get start index (index after pinned items)
             let startIndex = 0;
-            if (this.conversations[0].label == "Pinned" && !conv.pinned) { // If there are any pinned items
-                this.conversations.some( (conv, i) => {
+            if (this.unFilteredAllConversations[0].label == "Pinned" && !conv.pinned) { // If there are any pinned items
+                this.unFilteredAllConversations.some( (conv, i) => {
                     if (typeof conv.label != "undefined" // Loop until we find a label
                         && conv.label != "Pinned") { // That is not "pinned"
 
@@ -176,12 +185,12 @@ export default {
 
             // Move conversation if required
             if (conv_index != startIndex + 1) {
-                conv = this.conversations.splice(conv_index, 1)[0]
+                conv = this.unFilteredAllConversations.splice(conv_index, 1)[0]
 
                 // If top label is not "Today"
                 // This isn't elegant, but it works
-                if (this.conversations[startIndex].label != "Today"
-                    && this.conversations[startIndex].label != "Pinned") {
+                if (this.unFilteredAllConversations[startIndex].label != "Today"
+                    && this.unFilteredAllConversations[startIndex].label != "Pinned") {
                     const title = "Today"; // Define title
                     const label = {        // And Define Label
                         label: title,
@@ -189,13 +198,13 @@ export default {
                     }
 
                     // Push label and conversation
-                    this.conversations.splice(startIndex, 0, label, conv)
-
+                    this.unFilteredAllConversations.splice(startIndex, 0, label, conv)
                 } else { // Else, just push the converstation to index 1 (below label)
-
-                    this.conversations.splice(startIndex + 1, 0, conv)
+                    this.unFilteredAllConversations.splice(startIndex + 1, 0, conv)
                 }
             }
+
+            this.conversations = this.unFilteredAllConversations;
         },
 
         updateRead (id) {
@@ -214,8 +223,8 @@ export default {
             let conv_index = null;
             let conv = null;
 
-            for(conv_index in this.conversations) {
-                conv = this.conversations[conv_index];
+            for(conv_index in this.unFilteredAllConversations) {
+                conv = this.unFilteredAllConversations[conv_index];
 
                 if(id == conv.device_id)
                     return  { conv, conv_index };
@@ -239,6 +248,10 @@ export default {
 
         updateMargin (margin) {
             this.margin = margin;
+        },
+
+        toggleSearch () {
+            this.searchClicked = !this.searchClicked;
         },
 
         calculateTitle (conversation) {
@@ -303,7 +316,10 @@ export default {
             title: "",
             loading: true,
             conversations: [],
-            margin: 0
+            unFilteredAllConversations: [],
+            margin: 0,
+            searchClicked: false,
+            searchQuery: ""
         }
     },
 
@@ -315,6 +331,10 @@ export default {
         composeStyle () {
             return "background: " + this.$store.state.colors_accent + "; " +
                     "marginRight: " + (this.margin + 36) + "px;";
+        },
+
+        showSearch() {
+            return this.searchClicked && !this.small;
         }
     },
 
@@ -324,9 +344,15 @@ export default {
             // Only update if list page
             if (to.name != from.name && to.name.indexOf('conversations-list') >= 0) {
                 this.conversations = [];
+                this.unFilteredAllConversations = [];
+
                 this.fetchConversations();
             }
 
+        },
+
+        "searchQuery" (to, from) {
+            console.log("search query: " + to);
         }
     },
 
@@ -365,6 +391,39 @@ export default {
         }
     }
 
+    #quick_find {
+      white-space: nowrap;
+      padding-top: 5px;
+      text-align: right;
+    }
+
+    .quick_find {
+      width: 215px;
+      margin-top: 3px;
+      border: 0px solid white;
+      border-radius: 2px;
+      font-size: 15px;
+      background-color: white;
+      color: black;
+      background-position: 10px 10px;
+      background-repeat: no-repeat;
+      padding: 12px 16px 12px 16px;
+      -webkit-transition: width 0.4s ease-in-out;
+      transition: width 0.4s ease-in-out;
+      box-shadow: 0px 2px 2px rgba(0, 0, 0, .3);
+    }
+
+    .quick_find:focus {
+      width: 400px;
+      outline: none !important;
+    }
+
+    @media (max-width:450px) {
+      .quick_find:focus {
+        width: 250px;
+      }
+    }
+
     .flip-list-enter, .flip-list-leave-to	{
         opacity: 0;
     }
@@ -380,6 +439,12 @@ export default {
     body.dark {
         .empty-message {
             color: rgba(255, 255, 255, 0.54);
+        }
+
+        .quick_find {
+          border: 0px solid $bg-darker;
+          background-color: $bg-darker;
+          color: white;
         }
     }
 </style>

--- a/src/utils/shortcuts.js
+++ b/src/utils/shortcuts.js
@@ -28,6 +28,10 @@ export default class ShortcutKeys {
             _this.finish(event, "open compose page", () => { router.push('/compose') });
         });
 
+        hotkeys("control+shift+s,command+shift+s,alt+shift+s,ctrl+shift+s", function(event) {
+            _this.finish(event, "open search bar", () => { store.state.msgbus.$emit("search-btn") });
+        });
+
         hotkeys('control+e,command+e,alt+e,ctrl+e', function(event) {
             _this.finish(event, "opened the emoji input", () => { store.state.msgbus.$emit("hotkey-emoji") });
         });


### PR DESCRIPTION
Searching used to redirect the user to the old web app. That wasn't a great experience. This builds it directly into the conversation list. 

* clicking the search button displays the search bar
* clicking it again, hides the search bar
* whenever the search bar is hidden, the search text is cleared and the conversations are reset
* when entering text into the search bar, it will search the title and snippet of that conversation, and immediately filter the results.
* it adjusts correctly to the different themes, as well.
* the shortcut key combo in the commit will open it automatically

If a new message comes in, while the user is searching... It just clears the search and displays the full list. The logic here was non-trivial and I don't think it is a terribly common use-case.

Overall, very happy with how this turned out.

![screen shot 2018-07-26 at 8 38 55 pm](https://user-images.githubusercontent.com/4874287/43296957-05078804-9114-11e8-9be4-814f31213e7d.png)
