### PR TITLE
Don't push the login route, if we are already there

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -85,10 +85,11 @@ export default {
         this.$store.commit('title', "Pulse SMS");
 
         // If logged in (account_id) then setup crypto
-        if(this.$store.state.account_id != '')
+        if(this.$store.state.account_id != '') {
             Crypto.setupAes();
-        else
+        } else if (this.$route.name != 'login') {
             this.$router.push('login');
+        }
 
         navigator.serviceWorker && navigator.serviceWorker.register('/service-worker.js').then((registration) => {
             console.log('Registered SW with scope: ', registration.scope);


### PR DESCRIPTION
This closes #85.

It happened because we were simply already on the `/login` route. When setting up the routing, if we don't have the `account_id`, it pushes to the `/login` route [automatically](https://github.com/klinker-apps/messenger-web/blob/master/src/router/index.js#L179). 

I think we probably could remove this `else` branch completely, but there could be cases that I am not considering. I am not fully confident in it, so I would rather just leave it there with the condition.