### PR TITLE
[Experiment] Display Unread Count Feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-sms-web",
-  "version": "v1.1.1",
+  "version": "v1.1.2",
   "description": "Pulse SMS - text from your computer.",
   "license": "Apache 2.0 & MIT",
   "author": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -56,6 +56,11 @@
         <ImageViewer />
 
         <div class="file-drag"></div>
+
+        <!-- For external app access - like Franz, Rambox, or Station -->
+        <div id="unread_count">
+            {{ unread_count }}
+        </div>
     </div>
 </template>
 
@@ -189,6 +194,9 @@ export default {
                 return false;
             }
             return this.$store.state.theme_apply_appbar_color;
+        },
+        unread_count () { // For external app access - like Franz, Rambox, or Station
+            return this.$store.state.unread_count;
         }
     },
     watch: {
@@ -747,6 +755,11 @@ export default {
                 margin-left: 0px;
             }
         }
+    }
+
+    /* For external app access - like Franz, Rambox, or Station */
+    #unread_count {
+        display: none;
     }
 
     .mdl-layout__content {

--- a/src/components/Experiments.vue
+++ b/src/components/Experiments.vue
@@ -15,6 +15,14 @@
                     </span>
                 </label>
             </div>
+            <div class="label-item">
+                <label for="unread_count_in_sidebar" class="mdl-switch mdl-js-switch mdl-js-ripple-effect mdl-js-ripple-effect--ignore-events">
+                    <input id="unread_count_in_sidebar" v-model="unread_count_in_sidebar" class="mdl-switch__input" type="checkbox">
+                    <span class="mdl-switch__label mdl-color-text--grey-900">
+                        {{ $t('experiments.unread_count_in_sidebar') }}
+                    </span>
+                </label>
+            </div>
         </div>
     </div>
 </template>
@@ -28,6 +36,7 @@ export default {
         return {
             title: "Experiments",
             larger_app_bar: this.$store.state.larger_app_bar,
+            unread_count_in_sidebar: this.$store.state.unread_count_in_sidebar,
         };
     },
     watch: {
@@ -44,6 +53,10 @@ export default {
             else if (!this.larger_app_bar && body.className.includes(LARGER_APP_BAR))
                 body.className = body.className.replace(` ${LARGER_APP_BAR} `, "");
 
+        },
+
+        'unread_count_in_sidebar' () {
+            this.$store.commit('unread_count_in_sidebar', this.unread_count_in_sidebar);
         }
     },
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -9,6 +9,9 @@
                         <div class="link-card mdl-card mdl-js-button mdl-js-ripple-effect" :class="{ active: is_active('conversations') }">
                             <img src="../assets/images/holder.gif" width="24" height="24" class="icon conversations">
                             {{ $t('sidebar.conversations') }}
+                            <span v-if="display_unread">
+                                ({{ unread_count }})
+                            </span>
                         </div>
                     </li>
                     <li id="unread-link" @click="routeTo('unread')">
@@ -95,7 +98,7 @@ export default {
                 'scheduled': { name: 'scheduled-messages' }
             },
             listeners: [],
-            searchQuery: "",
+            searchQuery: ""
         };
     },
 
@@ -115,6 +118,12 @@ export default {
         showConversations () {
             return this.$route.name != 'conversations-list'
                 && this.$store.state.account_id != '';
+        },
+        display_unread () {
+            return this.$store.state.unread_count_in_sidebar;
+        },
+        unread_count () {
+            return this.$store.state.unread_count;
         }
     },
 

--- a/src/store/plugins.js
+++ b/src/store/plugins.js
@@ -22,6 +22,7 @@ const localStoreSync = store => {
         'notifications': KEYS.NOTIFICATIONS,
         'enter_to_send': KEYS.ENTER_TO_SEND,
         'larger_app_bar': KEYS.LARGER_APP_BAR,
+        'unread_count_in_sidebar': KEYS.UNREAD_COUNT_IN_SIDEBAR,
         'subscription_type': KEYS.SUBSCRIPTION_TYPE,
     };
 

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -10,6 +10,7 @@ export const KEYS  = {
     NOTIFICATIONS: 'notifications',
     ENTER_TO_SEND: 'enter_to_send',
     LARGER_APP_BAR: 'larger_app_bar',
+    UNREAD_COUNT_IN_SIDEBAR: 'unread_count_in_sidebar',
     SUBSCRIPTION_TYPE: 'subscription_type',
     THEME: {
         BASE: 'theme_base',
@@ -45,6 +46,7 @@ export const state = {
     notifications: JSON.parse( window.localStorage.getItem(KEYS.NOTIFICATIONS) || "true" ),
     enter_to_send: JSON.parse( window.localStorage.getItem(KEYS.ENTER_TO_SEND) || "true" ),
     larger_app_bar: JSON.parse( window.localStorage.getItem(KEYS.LARGER_APP_BAR) || "false" ),
+    unread_count_in_sidebar: JSON.parse( window.localStorage.getItem(KEYS.UNREAD_COUNT_IN_SIDEBAR) || "false" ),
     subscription_type: window.localStorage.getItem(KEYS.SUBSCRIPTION_TYPE) || 1,
 
     /* Per session */
@@ -110,6 +112,7 @@ export const mutations = {
     notifications: (state, notifications) => state.notifications = notifications,
     enter_to_send: (state, enter_to_send) => state.enter_to_send = enter_to_send,
     larger_app_bar: (state, larger_app_bar) => state.larger_app_bar = larger_app_bar,
+    unread_count_in_sidebar: (state, unread_count_in_sidebar) => state.unread_count_in_sidebar = unread_count_in_sidebar,
     subscription_type: (state, subscription_type) => state.subscription_type = subscription_type,
     media_loader: (state, media_loader) => state.media_loader = media_loader,
     colors_default: (state, colors_default) => state.colors_default = colors_default,

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -54,6 +54,7 @@ export const state = {
     title: "Pulse SMS",
     loading: true,
     hotkey_navigation: false,
+    unread_count: 0,
 
     colors_default: JSON.parse( window.localStorage.getItem(KEYS.THEME.GLOBAL_DEFAULT) || "\"#1775D2\"" ),
     colors_dark: JSON.parse( window.localStorage.getItem(KEYS.THEME.GLOBAL_DARK) || "\"#1665C0\"" ),
@@ -88,6 +89,9 @@ export const mutations = {
     title: (state, title) => state.title = title,
     loading: (state, loading) => state.loading = loading,
     hotkey_navigation: (state, hotkey_navigation) => state.hotkey_navigation = hotkey_navigation,
+    unread_count: (state, unread_count) => state.unread_count = unread_count,
+    increment_unread_count: (state) => state.unread_count++,
+    decrement_unread_count: (state) => state.unread_count--,
     full_theme: (state, full_theme) => state.full_theme = full_theme,
     sidebar_open: (state, sidebar_open) => state.sidebar_open = sidebar_open,
     account_id: (state, account_id) => state.account_id = account_id,

--- a/src/utils/translations.js
+++ b/src/utils/translations.js
@@ -146,6 +146,7 @@ export const i18n = new VueI18n({
                 disclaimer: 'Disclaimer',
                 explanatory_intro: 'These preferences come with no support and no guarentee that they will continue to exist. As an open source app, they will be useful to test new features and provide developers with the means of implementing their own tweaks into the app. Use with caution and do not rely on them, unless you are maintaining them. They are meant to be experiments.',
                 larger_app_bar: 'Display Larger App Bar',
+                unread_count_in_sidebar: 'Display Unread Messages Count in Sidebar',
             }
         },
         fr: {


### PR DESCRIPTION
This enables an experiment to display an unread count next to the "Conversations" tab. This also enables an invisible unread count for external app access such as Franz, Rambox, or Station.