### PR TITLE
Autocomplete Emojis (Github/Slack Style)

### DIFF
--- a/src/components/Thread/EmojiAutocompleteSuggestion.vue
+++ b/src/components/Thread/EmojiAutocompleteSuggestion.vue
@@ -44,32 +44,32 @@ export default {
 @import "../../assets/scss/_vars.scss";
 
 .click-item {
-  background: #fafafa;
-  position: relative;
-  width: 100%;
-  padding: 12px;
-  line-height: 18px;
-  border-radius: 3px;
-  margin-top: -3px;
-
-  -webkit-user-select: text;
-  -moz-user-select: text;
-  -ms-user-select: text;
-  user-select: text;
+    background: #fafafa;
+    position: relative;
+    width: 100%;
+    padding: 12px;
+    line-height: 18px;
+    border-radius: 3px;
+    margin-top: -3px;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
 }
 
-.click-item:hover, .is-active {
-  background: #e0e0e0;
-  cursor: pointer;
+.click-item:hover,
+.is-active {
+    background: #e0e0e0;
+    cursor: pointer;
 }
 
 body.dark {
-  .click-item {
-    background: #202024;
-  }
-
-  .click-item:hover, .is-active {
-    background: #282828;
-  }
+    .click-item {
+        background: #202024;
+    }
+    .click-item:hover,
+    .is-active {
+        background: #282828;
+    }
 }
 </style>

--- a/src/components/Thread/EmojiAutocompleteSuggestion.vue
+++ b/src/components/Thread/EmojiAutocompleteSuggestion.vue
@@ -1,0 +1,71 @@
+<template>
+    <div>
+        <div class="click-item mdl-js-button mdl-js-ripple-effect" @click="onClick">
+            <div class="mdl-color-text--grey-900">
+                {{ emojiImage }} {{ emojiName }}
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "EmojiAutocompleteSuggestion",
+    props: ["emoji", "onSelected"],
+
+    data() {
+        return {
+            emojiImage: this.emoji.emoji,
+            emojiName: this.emoji.title
+        };
+    },
+
+    methods: {
+        onClick() {
+            this.onSelected(this.emojiImage);
+        }
+    }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style lang="scss" scoped>
+@import "../../assets/scss/_vars.scss";
+
+.item,
+.click-item {
+  background: #fafafa;
+  position: relative;
+  width: 100%;
+  padding: 12px;
+  line-height: 18px;
+  border-radius: 3px;
+  margin-top: -3px;
+
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+
+.item:hover,
+.click-item:hover {
+  background: #e0e0e0;
+}
+
+.click-item:hover {
+  cursor: pointer;
+}
+
+body.dark {
+  .item,
+  .click-item {
+    background: #202024;
+  }
+
+  .item:hover,
+  .click-item:hover {
+    background: #282828;
+  }
+}
+</style>

--- a/src/components/Thread/EmojiAutocompleteSuggestion.vue
+++ b/src/components/Thread/EmojiAutocompleteSuggestion.vue
@@ -2,7 +2,7 @@
     <div>
         <div class="click-item mdl-js-button mdl-js-ripple-effect" @click="onClick">
             <div class="mdl-color-text--grey-900">
-                {{ emojiImage }} {{ emojiName }}
+                {{ emojiImage }} {{ emojiCode }}
             </div>
         </div>
     </div>
@@ -16,7 +16,7 @@ export default {
     data() {
         return {
             emojiImage: this.emoji.emoji,
-            emojiName: this.emoji.title
+            emojiCode: `:${this.emoji.code}`
         };
     },
 

--- a/src/components/Thread/EmojiAutocompleteSuggestion.vue
+++ b/src/components/Thread/EmojiAutocompleteSuggestion.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div class="click-item mdl-js-button mdl-js-ripple-effect" @click="onClick">
+        <div :class="classes" @click="onClick">
             <div class="mdl-color-text--grey-900">
                 {{ emojiImage }} {{ emojiCode }}
             </div>
@@ -11,13 +11,24 @@
 <script>
 export default {
     name: "EmojiAutocompleteSuggestion",
-    props: ["emoji", "onSelected"],
+    props: ["emoji", "onSelected", "isActive"],
 
     data() {
         return {
             emojiImage: this.emoji.emoji,
             emojiCode: `:${this.emoji.code}`
         };
+    },
+
+    computed: {
+        classes () {
+            let base = "click-item mdl-js-button mdl-js-ripple-effect";
+            if (this.isActive) {
+                base = base + " is-active";
+            }
+
+            return base;
+        }
     },
 
     methods: {
@@ -32,7 +43,6 @@ export default {
 <style lang="scss" scoped>
 @import "../../assets/scss/_vars.scss";
 
-.item,
 .click-item {
   background: #fafafa;
   position: relative;
@@ -48,23 +58,17 @@ export default {
   user-select: text;
 }
 
-.item:hover,
-.click-item:hover {
+.click-item:hover, .is-active {
   background: #e0e0e0;
-}
-
-.click-item:hover {
   cursor: pointer;
 }
 
 body.dark {
-  .item,
   .click-item {
     background: #202024;
   }
 
-  .item:hover,
-  .click-item:hover {
+  .click-item:hover, .is-active {
     background: #282828;
   }
 }

--- a/src/components/Thread/Sendbar.vue
+++ b/src/components/Thread/Sendbar.vue
@@ -48,7 +48,7 @@
                 <transition-group name="flip-list" tag="div">
                     <emoji-autocomplete-suggestion
                         v-for="suggestion in emojiAutocompleteSuggestions"
-                        :key="suggestion.title"
+                        :key="suggestion.code"
                         :emoji="suggestion"
                         :on-selected="selectAutocompleteEmoji"
                     />
@@ -156,7 +156,7 @@ export default {
             const lastIndex = cursorContextMessage.length - 1;
             if (lastIndexSemicolon != -1 && lastIndexSemicolon > cursorContextMessage.lastIndexOf(" ") && lastIndexSemicolon != lastIndex) {
                 const emojiSearch = cursorContextMessage.substring(lastIndexSemicolon + 1, lastIndex + 1);
-                this.emojiAutocompleteSuggestions = this.emojiIndex.search(emojiSearch).map((o) => ({ emoji: o.native, title: o.name }));
+                this.emojiAutocompleteSuggestions = this.emojiIndex.search(emojiSearch).map((o) => ({ emoji: o.native, code: o.short_name }));
             } else {
                 this.emojiAutocompleteSuggestions = [];
             }
@@ -202,10 +202,6 @@ export default {
     destroy () {
         document.documentElement.removeEventListener('paste');
         this.$store.state.msgbus.$off('hotkey-emoji', this.toggle);
-
-        if (this.autocomplete != null) {
-            this.autocomplete.destroy();
-        }
     },
 
     methods: {
@@ -217,23 +213,9 @@ export default {
          */
         dispatchSend(e) { // Dispatch send message when clicked
 
-            if (e instanceof KeyboardEvent && this.autocomplete != null) {
-                // todo select first option?
-                this.destroyAutoComplete();
-
-                // Get start/end of selection for insert location
-                const start = e.target.selectionStart;
-                const end =  e.target.selectionEnd;
-
-                // Overwrite selection with newline
-                this.message = this.message.substr(0,start)
-                    + " " + this.message.substr(end, this.message.length);
-
-                // Set new location of selection to start of old selection
-                // Wait until next tick to ensure the new message gets rendered
-                Vue.nextTick(() =>
-                    e.target.setSelectionRange(start + 1, start + 1)
-                );
+            if (e instanceof KeyboardEvent && this.autocomplete_emoji) {
+                const emoji = this.emojiAutocompleteSuggestions[0].emoji;
+                this.selectAutocompleteEmoji(emoji);
 
                 return;
             }

--- a/src/components/Thread/Sendbar.vue
+++ b/src/components/Thread/Sendbar.vue
@@ -1,27 +1,78 @@
 <template>
     <div v-mdl class="send-bar">
-        <div v-mdl class="mdl-progress mdl-js-progress mdl-progress__indeterminate" :style="{ display: loading ? '' : 'none' }"></div>
+        <div
+            v-mdl
+            class="mdl-progress mdl-js-progress mdl-progress__indeterminate"
+            :style="{ display: loading ? '' : 'none' }"
+        ></div>
         <div v-if="$store.state.loaded_media" v-mdl class="preview">
             <div class="overlay">
-                <button class="media-clear mdl-button mdl-js-button mdl-button--colored mdl-button--fab mdl-js-ripple-effect" :style="{ background: send_color }" @click="removeMedia">
+                <button
+                    class="media-clear mdl-button mdl-js-button mdl-button--colored mdl-button--fab mdl-js-ripple-effect"
+                    :style="{ background: send_color }"
+                    @click="removeMedia"
+                >
                     <i class="material-icons">clear</i>
                 </button>
             </div>
             <img :src="media_blob">
         </div>
         <div id="sendbar" class="send-bar-inner">
-            <input id="attach" class="mdl-button mdl-js-button mdl-button--icon attach-button" readonly tabindex="-1" @click.prevent="attachMedia">
-            <input id="emoji" class="mdl-button mdl-js-button mdl-button--icon emoji-button" readonly tabindex="-1" @click="toggleEmoji">
+            <input
+                id="attach"
+                class="mdl-button mdl-js-button mdl-button--icon attach-button"
+                readonly
+                tabindex="-1"
+                @click.prevent="attachMedia"
+            >
+            <input
+                id="emoji"
+                class="mdl-button mdl-js-button mdl-button--icon emoji-button"
+                readonly
+                tabindex="-1"
+                @click="toggleEmoji"
+            >
             <div v-show="show_emoji" id="emoji-wrapper" @click.self="toggleEmoji">
-                <nimble-picker title="Pick your emoji…" :style="emojiStyle" :set="set" :sheet-size="sheetSize" :per-line="perLine" :skins="skin" :data="emojiIndex" @select="insertEmoji" />
+                <nimble-picker
+                    title="Pick your emoji…"
+                    :style="emojiStyle"
+                    :set="set"
+                    :sheet-size="sheetSize"
+                    :per-line="perLine"
+                    :skins="skin"
+                    :data="emojiIndex"
+                    @select="insertEmoji"
+                />
+            </div>
+            <div v-show="autocomplete_emoji" id="emoji-autocomplete" :style="emojiAutocompleteStyle">
+                <transition-group name="flip-list" tag="div">
+                    <emoji-autocomplete-suggestion
+                        v-for="suggestion in emojiAutocompleteSuggestions"
+                        :key="suggestion.title"
+                        :emoji="suggestion"
+                        :on-selected="selectAutocompleteEmoji"
+                    />
+                </transition-group>
             </div>
             <div v-mdl class="entry mdl-textfield mdl-js-textfield" :class="is_dirty">
-                <!-- eslint-disable-next-line vue/use-v-on-exact -->
-                <textarea id="message-entry" v-model="message" class="mdl-textfield__input disabled" type="text" @keydown.shift.enter.stop @keydown.enter.prevent.stop="dispatchSend"></textarea>
+                <!-- eslint-disable vue/use-v-on-exact -->
+                <textarea
+                    id="message-entry"
+                    v-model="message"
+                    class="mdl-textfield__input disabled"
+                    type="text"
+                    @keydown.shift.enter.stop
+                    @keydown.enter.prevent.stop="dispatchSend"
+                ></textarea>
                 <label class="mdl-textfield__label" for="message-entry">{{ $t('sendbar.type') }}</label>
             </div>
             <!-- fab with correct colors will be inserted here -->
-            <button id="send-button" class="send mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored mdl-js-ripple-effect" :style="{ background: send_color }" @click="dispatchSend">
+            <button
+                id="send-button"
+                class="send mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored mdl-js-ripple-effect"
+                :style="{ background: send_color }"
+                @click="dispatchSend"
+            >
                 <i class="material-icons md-18 material-icons-white">send</i>
             </button>
         </div>
@@ -30,6 +81,7 @@
 
 <script>
 import Vue from 'vue';
+import EmojiAutocompleteSuggestion from './EmojiAutocompleteSuggestion.vue';
 import AutoGrow from '@/lib/textarea-autogrow.js';
 import data from 'emoji-mart-vue-fast/data/all.json';
 import 'emoji-mart-vue-fast/css/emoji-mart.css';
@@ -40,6 +92,7 @@ export default {
     name: 'Sendbar',
     components: {
         NimblePicker,
+        EmojiAutocompleteSuggestion,
     },
     props: ['threadId', 'onSend', 'loading'],
 
@@ -52,6 +105,12 @@ export default {
                 bottom: "70px",
                 width: "18em",
             },
+            emojiAutocompleteStyle: {
+                position: "absolute",
+                left: "72px",
+                bottom: "67px",
+                width: "18em",
+            },
             perLine: 6,
             set: 'twitter',
             emojiIndex: new EmojiIndex(data),
@@ -60,6 +119,7 @@ export default {
             show_emoji: false,
             $wrapper: null,
             $sendbar: null,
+            emojiAutocompleteSuggestions: [],
         };
     },
 
@@ -78,6 +138,9 @@ export default {
         },
         media_blob () { // creates url object from media blob
             return window.URL.createObjectURL(this.$store.state.loaded_media);
+        },
+        autocomplete_emoji () {
+            return this.emojiAutocompleteSuggestions.length > 0;
         }
     },
 
@@ -88,12 +151,14 @@ export default {
         },
 
         'message' () {
-            const lastIndexSemicolon = this.message.lastIndexOf(":");
-            const lastIndex = this.message.length - 1;
-            if (lastIndexSemicolon > this.message.lastIndexOf(" ") && lastIndexSemicolon != lastIndex) {
-                const emojiSearch = this.message.substring(lastIndexSemicolon + 1, lastIndex + 1);
-                const emojiOptions = this.emojiIndex.search(emojiSearch).map((o) => ({ emoji: o.native, title: o.name }));
-                console.log(emojiOptions);
+            const cursorContextMessage = this.message.substr(0, this.$sendbar.selectionStart);
+            const lastIndexSemicolon = cursorContextMessage.lastIndexOf(":");
+            const lastIndex = cursorContextMessage.length - 1;
+            if (lastIndexSemicolon != -1 && lastIndexSemicolon > cursorContextMessage.lastIndexOf(" ") && lastIndexSemicolon != lastIndex) {
+                const emojiSearch = cursorContextMessage.substring(lastIndexSemicolon + 1, lastIndex + 1);
+                this.emojiAutocompleteSuggestions = this.emojiIndex.search(emojiSearch).map((o) => ({ emoji: o.native, title: o.name }));
+            } else {
+                this.emojiAutocompleteSuggestions = [];
             }
         }
     },
@@ -137,6 +202,10 @@ export default {
     destroy () {
         document.documentElement.removeEventListener('paste');
         this.$store.state.msgbus.$off('hotkey-emoji', this.toggle);
+
+        if (this.autocomplete != null) {
+            this.autocomplete.destroy();
+        }
     },
 
     methods: {
@@ -147,6 +216,27 @@ export default {
          * @param e - event object
          */
         dispatchSend(e) { // Dispatch send message when clicked
+
+            if (e instanceof KeyboardEvent && this.autocomplete != null) {
+                // todo select first option?
+                this.destroyAutoComplete();
+
+                // Get start/end of selection for insert location
+                const start = e.target.selectionStart;
+                const end =  e.target.selectionEnd;
+
+                // Overwrite selection with newline
+                this.message = this.message.substr(0,start)
+                    + " " + this.message.substr(end, this.message.length);
+
+                // Set new location of selection to start of old selection
+                // Wait until next tick to ensure the new message gets rendered
+                Vue.nextTick(() =>
+                    e.target.setSelectionRange(start + 1, start + 1)
+                );
+
+                return;
+            }
 
             // the shift key will be used to toggle between the send and return functionality, based
             // on the users "enter to send" preference, in settings.
@@ -202,6 +292,7 @@ export default {
          * @param e - event object (optional)
          */
         attachMedia () {
+            this.destroyAutoComplete();
 
             // Create input to attach file
             const input = document.createElement('input');
@@ -235,6 +326,7 @@ export default {
          * @param toggle - toggle override (default: null)
          */
         toggleEmoji (toggle=null) {
+            this.destroyAutoComplete();
 
             // Update emoji wrapper margin
             this.updateEmojiMargin(true);
@@ -277,6 +369,8 @@ export default {
          * @param e emoji event
          */
         insertEmoji(e) {
+            this.destroyAutoComplete();
+
             // Get start/end of selection for insert location
             const start = this.$sendbar.selectionStart;
             const end =  this.$sendbar.selectionEnd;
@@ -290,6 +384,29 @@ export default {
             Vue.nextTick(() =>
                 this.$sendbar.setSelectionRange(start + e.native.length, start + e.native.length)
             );
+        },
+
+        selectAutocompleteEmoji(emoji) {
+            this.destroyAutoComplete();
+
+            // Get start/end of selection for insert location
+            const cursorContextMessage = this.message.substr(0, this.$sendbar.selectionStart);
+            const start = cursorContextMessage.lastIndexOf(":");
+            const end = cursorContextMessage.length;
+
+            // Overwrite selection with emoji
+            this.message = this.message.substr(0,start)
+                + emoji + this.message.substr(end, this.message.length);
+
+            // Set new location of selection to start of old selection
+            // Wait until next tick to ensure the new message gets rendered
+            Vue.nextTick(() =>
+                this.$sendbar.setSelectionRange(start + emoji.length, start + emoji.length)
+            );
+        },
+
+        destroyAutoComplete () {
+            this.emojiAutocompleteSuggestions = [];
         }
     }
 };
@@ -299,241 +416,252 @@ export default {
 <style lang="scss" scoped>
 @import "../../assets/scss/_vars.scss";
 
-    #emoji {
-        background: url("../../assets/images/ic_mood.png") no-repeat;
-        background-size: cover;
-    }
+#emoji {
+  background: url("../../assets/images/ic_mood.png") no-repeat;
+  background-size: cover;
+}
 
-    #attach {
-        background: url("../../assets/images/ic_attach.png") no-repeat;
-        background-size: cover;
-        margin-top: 18px;
+#attach {
+  background: url("../../assets/images/ic_attach.png") no-repeat;
+  background-size: cover;
+  margin-top: 18px;
+  width: 24px;
+  height: 24px;
+}
+
+body.dark {
+  #emoji {
+    background: url("../../assets/images/ic_mood_white.png") no-repeat;
+    background-size: cover;
+  }
+
+  #attach {
+    background: url("../../assets/images/ic_attach_white.png") no-repeat;
+    background-size: cover;
+  }
+}
+
+.send-bar {
+  height: auto;
+  width: 100%;
+  margin: auto;
+  position: fixed;
+  bottom: 0%;
+  clear: both;
+  transition: ease-in-out width $anim-time;
+
+  .mdl-progress {
+    width: 100%;
+  }
+
+  .preview {
+    position: relative;
+    background: #fafafa;
+    max-height: 300px;
+    overflow: hidden;
+    border-radius: 15px;
+    margin-bottom: 10px;
+    box-shadow: -0px -0px 3px rgba(0, 0, 0, 0.15);
+
+    .overlay {
+      background: linear-gradient(
+        to bottom,
+        rgba(250, 250, 250, 0) 95%,
+        rgba(250, 250, 250, 1) 100%
+      );
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      height: 100%;
+      width: 100%;
+      z-index: 10;
+
+      .media-clear {
+        position: absolute;
+        margin: 0.3em 1em;
+        background: rgb(33, 150, 243) none repeat scroll 0% 0%;
+        padding: 0.3em;
+        right: 1em;
         width: 24px;
+        min-width: 24px;
+        min-height: 24px;
         height: 24px;
-    }
-
-    body.dark {
-      #emoji {
-          background: url("../../assets/images/ic_mood_white.png") no-repeat;
-          background-size: cover;
       }
 
-      #attach {
-          background: url("../../assets/images/ic_attach_white.png") no-repeat;
-          background-size: cover;
+      .media-clear i {
+        width: 24px;
+        font-size: 18px;
+        line-height: 24px;
+        height: 24px;
       }
     }
 
-    .send-bar {
-        height: auto;
-        width: 100%;
-        margin: auto;
-        position: fixed;
-        bottom: 0%;
-        clear: both;
-        transition: ease-in-out width $anim-time;
-
-        .mdl-progress {
-            width: 100%;
-        }
-
-        .preview {
-            position: relative;
-            background: #fafafa;
-            max-height: 300px;
-            overflow: hidden;
-            border-radius: 15px;
-            margin-bottom: 10px;
-            box-shadow: -0px -0px 3px rgba(0, 0, 0, .15);
-
-            .overlay {
-                background: linear-gradient(to bottom, rgba(250,250,250,0) 95%,rgba(250,250,250,1) 100%);
-                position: absolute;
-                top: 0;
-                bottom: 0;
-                height: 100%;
-                width: 100%;
-                z-index: 10;
-
-                .media-clear {
-                    position: absolute;
-                    margin: 0.3em 1em;
-                    background: rgb(33, 150, 243) none repeat scroll 0% 0%;
-                    padding: 0.3em;
-                    right: 1em;
-                    width: 24px;
-                    min-width: 24px;
-                    min-height: 24px;
-                    height: 24px;
-                }
-
-                .media-clear i {
-                    width: 24px;
-                    font-size: 18px;
-                    line-height: 24px;
-                    height: 24px;
-                }
-            }
-
-            img {
-                margin: 1em calc(24px + 16px + 8px) 1em;
-                width: calc(100% - 108px);
-            }
-        }
-
-        @media (min-width: 750px) {
-            & {
-                width: 450px;
-            }
-        }
-        @media (min-width: 800px) {
-            & {
-                width: 490px;
-            }
-        }
-        @media (min-width: 820px) {
-            & {
-                width: 505px;
-            }
-        }
-        @media (min-width: 850px) {
-            & {
-                width: 530px;
-            }
-        }
-        @media (min-width: 870px) {
-            & {
-                width: 550px;
-            }
-        }
-        @media (min-width: 890px) {
-            & {
-                width: 570px;
-            }
-        }
-        @media (min-width: 920px) {
-            & {
-                width: 600px;
-            }
-        }
-        @media (min-width:950px) {
-            & {
-                width: 630px;
-            }
-        }
+    img {
+      margin: 1em calc(24px + 16px + 8px) 1em;
+      width: calc(100% - 108px);
     }
+  }
 
-    .mdl-textfield {
-        padding: 0px 0;
-        padding-top: 20px;
+  @media (min-width: 750px) {
+    & {
+      width: 450px;
     }
-
-    .mdl-textfield__input {
-        min-height: 2em;
-        transition: height ease-in-out $anim-time;
-        outline: none;
+  }
+  @media (min-width: 800px) {
+    & {
+      width: 490px;
     }
-
-    .mdl-textfield__label:after {
-        background-color: rgba(0,0,0,0);
-        bottom: 1px;
-        height: 1px;
+  }
+  @media (min-width: 820px) {
+    & {
+      width: 505px;
     }
-
-    .send-bar-inner {
-        background: #fafafa;
-        height: 100%;
-        margin: auto;
-        padding-left: 16px;
-        padding-right: 16px;
-        padding-top: 4px;
-        padding-bottom: 4px;
-        border-radius: 16px 16px 0px 0px;
-        box-shadow: -0px -0px 3px rgba(0, 0, 0, .15);
-
-        .entry {
-            width: calc(100% - 124px);
-            margin-top: -4px;
-        }
-
-        .send {
-            float: right;
-            margin-top: 8px;
-        }
-
-        .attach-button {
-            float: left;
-            text-align: center;
-            margin-top: 15px;
-            min-width: 0px;
-            width: 28px;
-            height: 28px;
-            opacity: .56;
-            margin-right: 8px;
-        }
-
-        .emoji-button {
-            float: left;
-            text-align: center;
-            margin-top: 18px;
-            min-width: 0px;
-            width: 24px;
-            height: 24px;
-            opacity: .56;
-            margin-right: 16px;
-        }
+  }
+  @media (min-width: 850px) {
+    & {
+      width: 530px;
     }
-
-    #message-entry {
-        height: 24px;
-        resize: none;
+  }
+  @media (min-width: 870px) {
+    & {
+      width: 550px;
     }
-
-    #emoji-wrapper {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        z-index: 10;
-
-        .emoji-mart {
-            z-index: 15;
-            transition: ease-in-out left $anim-time;
-        }
+  }
+  @media (min-width: 890px) {
+    & {
+      width: 570px;
     }
-
-    body.dark {
-        .preview {
-            background: rgb(32,32,36);
-
-            .overlay {
-                background: linear-gradient(to bottom, rgba(32,32,36,0) 95%,rgba(32,32,36,1) 100%);
-            }
-        }
-
-        .send-bar-inner {
-            background: #202024;
-            color: #fff;
-        }
-
-        .mdl-textfield__label {
-            color: #fff !important;
-        }
+  }
+  @media (min-width: 920px) {
+    & {
+      width: 600px;
     }
-
-    body.black {
-        .preview {
-            background: rgb(0,0,0);
-
-            .overlay {
-                background: linear-gradient(to bottom, rgba(0,0,0,0) 95%,rgba(0,0,0,1) 100%);
-            }
-        }
-
-        .send-bar-inner {
-            background: #000000;
-        }
+  }
+  @media (min-width: 950px) {
+    & {
+      width: 630px;
     }
+  }
+}
 
+.mdl-textfield {
+  padding: 0px 0;
+  padding-top: 20px;
+}
+
+.mdl-textfield__input {
+  min-height: 2em;
+  transition: height ease-in-out $anim-time;
+  outline: none;
+}
+
+.mdl-textfield__label:after {
+  background-color: rgba(0, 0, 0, 0);
+  bottom: 1px;
+  height: 1px;
+}
+
+.send-bar-inner {
+  background: #fafafa;
+  height: 100%;
+  margin: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  border-radius: 16px 16px 0px 0px;
+  box-shadow: -0px -0px 3px rgba(0, 0, 0, 0.15);
+
+  .entry {
+    width: calc(100% - 124px);
+    margin-top: -4px;
+  }
+
+  .send {
+    float: right;
+    margin-top: 8px;
+  }
+
+  .attach-button {
+    float: left;
+    text-align: center;
+    margin-top: 15px;
+    min-width: 0px;
+    width: 28px;
+    height: 28px;
+    opacity: 0.56;
+    margin-right: 8px;
+  }
+
+  .emoji-button {
+    float: left;
+    text-align: center;
+    margin-top: 18px;
+    min-width: 0px;
+    width: 24px;
+    height: 24px;
+    opacity: 0.56;
+    margin-right: 16px;
+  }
+}
+
+#message-entry {
+  height: 24px;
+  resize: none;
+}
+
+#emoji-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+
+  .emoji-mart {
+    z-index: 15;
+    transition: ease-in-out left $anim-time;
+  }
+}
+
+body.dark {
+  .preview {
+    background: rgb(32, 32, 36);
+
+    .overlay {
+      background: linear-gradient(
+        to bottom,
+        rgba(32, 32, 36, 0) 95%,
+        rgba(32, 32, 36, 1) 100%
+      );
+    }
+  }
+
+  .send-bar-inner {
+    background: #202024;
+    color: #fff;
+  }
+
+  .mdl-textfield__label {
+    color: #fff !important;
+  }
+}
+
+body.black {
+  .preview {
+    background: rgb(0, 0, 0);
+
+    .overlay {
+      background: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0) 95%,
+        rgba(0, 0, 0, 1) 100%
+      );
+    }
+  }
+
+  .send-bar-inner {
+    background: #000000;
+  }
+}
 </style>

--- a/src/components/Thread/Sendbar.vue
+++ b/src/components/Thread/Sendbar.vue
@@ -1,81 +1,32 @@
 <template>
     <div v-mdl class="send-bar">
-        <div
-            v-mdl
-            class="mdl-progress mdl-js-progress mdl-progress__indeterminate"
-            :style="{ display: loading ? '' : 'none' }"
-        ></div>
+        <div v-mdl class="mdl-progress mdl-js-progress mdl-progress__indeterminate" :style="{ display: loading ? '' : 'none' }"></div>
         <div v-if="$store.state.loaded_media" v-mdl class="preview">
             <div class="overlay">
-                <button
-                    class="media-clear mdl-button mdl-js-button mdl-button--colored mdl-button--fab mdl-js-ripple-effect"
-                    :style="{ background: send_color }"
-                    @click="removeMedia"
-                >
+                <button class="media-clear mdl-button mdl-js-button mdl-button--colored mdl-button--fab mdl-js-ripple-effect" :style="{ background: send_color }" @click="removeMedia">
                     <i class="material-icons">clear</i>
                 </button>
             </div>
             <img :src="media_blob">
         </div>
         <div id="sendbar" class="send-bar-inner">
-            <input
-                id="attach"
-                class="mdl-button mdl-js-button mdl-button--icon attach-button"
-                readonly
-                tabindex="-1"
-                @click.prevent="attachMedia"
-            >
-            <input
-                id="emoji"
-                class="mdl-button mdl-js-button mdl-button--icon emoji-button"
-                readonly
-                tabindex="-1"
-                @click="toggleEmoji"
-            >
+            <input id="attach" class="mdl-button mdl-js-button mdl-button--icon attach-button" readonly tabindex="-1" @click.prevent="attachMedia">
+            <input id="emoji" class="mdl-button mdl-js-button mdl-button--icon emoji-button" readonly tabindex="-1" @click="toggleEmoji">
             <div v-show="show_emoji" id="emoji-wrapper" @click.self="toggleEmoji">
-                <nimble-picker
-                    title="Pick your emoji…"
-                    :style="emojiStyle"
-                    :set="set"
-                    :sheet-size="sheetSize"
-                    :per-line="perLine"
-                    :skins="skin"
-                    :data="emojiIndex"
-                    @select="insertEmoji"
-                />
+                <nimble-picker title="Pick your emoji…" :style="emojiStyle" :set="set" :sheet-size="sheetSize" :per-line="perLine" :skins="skin" :data="emojiIndex" @select="insertEmoji" />
             </div>
             <div v-show="autocomplete_emoji" id="emoji-autocomplete" :style="emojiAutocompleteStyle">
                 <transition-group name="flip-list" tag="div">
-                    <emoji-autocomplete-suggestion
-                        v-for="(suggestion, i) in emojiAutocompleteSuggestions"
-                        :key="suggestion.code"
-                        :emoji="suggestion"
-                        :on-selected="selectAutocompleteEmoji"
-                        :is-active="i === emojiSelectedIndex"
-                    />
+                    <emoji-autocomplete-suggestion v-for="(suggestion, i) in emojiAutocompleteSuggestions" :key="suggestion.code" :emoji="suggestion" :on-selected="selectAutocompleteEmoji" :is-active="i === emojiSelectedIndex" />
                 </transition-group>
             </div>
             <div v-mdl class="entry mdl-textfield mdl-js-textfield" :class="is_dirty">
                 <!-- eslint-disable vue/use-v-on-exact -->
-                <textarea
-                    id="message-entry"
-                    v-model="message"
-                    class="mdl-textfield__input disabled"
-                    type="text"
-                    @keydown.down.exact.prevent.stop="onArrowUp"
-                    @keydown.up.exact.prevent.stop="onArrowDown"
-                    @keydown.shift.enter.stop
-                    @keydown.enter.prevent.stop="dispatchSend"
-                ></textarea>
+                <textarea id="message-entry" v-model="message" class="mdl-textfield__input disabled" type="text" @keydown.down.exact.prevent.stop="onArrowUp" @keydown.up.exact.prevent.stop="onArrowDown" @keydown.shift.enter.stop @keydown.enter.prevent.stop="dispatchSend"></textarea>
                 <label class="mdl-textfield__label" for="message-entry">{{ $t('sendbar.type') }}</label>
             </div>
             <!-- fab with correct colors will be inserted here -->
-            <button
-                id="send-button"
-                class="send mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored mdl-js-ripple-effect"
-                :style="{ background: send_color }"
-                @click="dispatchSend"
-            >
+            <button id="send-button" class="send mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored mdl-js-ripple-effect" :style="{ background: send_color }" @click="dispatchSend">
                 <i class="material-icons md-18 material-icons-white">send</i>
             </button>
         </div>
@@ -416,251 +367,221 @@ export default {
 @import "../../assets/scss/_vars.scss";
 
 #emoji {
-  background: url("../../assets/images/ic_mood.png") no-repeat;
-  background-size: cover;
+    background: url("../../assets/images/ic_mood.png") no-repeat;
+    background-size: cover;
 }
 
 #attach {
-  background: url("../../assets/images/ic_attach.png") no-repeat;
-  background-size: cover;
-  margin-top: 18px;
-  width: 24px;
-  height: 24px;
+    background: url("../../assets/images/ic_attach.png") no-repeat;
+    background-size: cover;
+    margin-top: 18px;
+    width: 24px;
+    height: 24px;
 }
 
 body.dark {
-  #emoji {
-    background: url("../../assets/images/ic_mood_white.png") no-repeat;
-    background-size: cover;
-  }
-
-  #attach {
-    background: url("../../assets/images/ic_attach_white.png") no-repeat;
-    background-size: cover;
-  }
+    #emoji {
+        background: url("../../assets/images/ic_mood_white.png") no-repeat;
+        background-size: cover;
+    }
+    #attach {
+        background: url("../../assets/images/ic_attach_white.png") no-repeat;
+        background-size: cover;
+    }
 }
 
 .send-bar {
-  height: auto;
-  width: 100%;
-  margin: auto;
-  position: fixed;
-  bottom: 0%;
-  clear: both;
-  transition: ease-in-out width $anim-time;
-
-  .mdl-progress {
+    height: auto;
     width: 100%;
-  }
-
-  .preview {
-    position: relative;
-    background: #fafafa;
-    max-height: 300px;
-    overflow: hidden;
-    border-radius: 15px;
-    margin-bottom: 10px;
-    box-shadow: -0px -0px 3px rgba(0, 0, 0, 0.15);
-
-    .overlay {
-      background: linear-gradient(
-        to bottom,
-        rgba(250, 250, 250, 0) 95%,
-        rgba(250, 250, 250, 1) 100%
-      );
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      height: 100%;
-      width: 100%;
-      z-index: 10;
-
-      .media-clear {
-        position: absolute;
-        margin: 0.3em 1em;
-        background: rgb(33, 150, 243) none repeat scroll 0% 0%;
-        padding: 0.3em;
-        right: 1em;
-        width: 24px;
-        min-width: 24px;
-        min-height: 24px;
-        height: 24px;
-      }
-
-      .media-clear i {
-        width: 24px;
-        font-size: 18px;
-        line-height: 24px;
-        height: 24px;
-      }
+    margin: auto;
+    position: fixed;
+    bottom: 0%;
+    clear: both;
+    transition: ease-in-out width $anim-time;
+    .mdl-progress {
+        width: 100%;
     }
-
-    img {
-      margin: 1em calc(24px + 16px + 8px) 1em;
-      width: calc(100% - 108px);
+    .preview {
+        position: relative;
+        background: #fafafa;
+        max-height: 300px;
+        overflow: hidden;
+        border-radius: 15px;
+        margin-bottom: 10px;
+        box-shadow: -0px -0px 3px rgba(0, 0, 0, 0.15);
+        .overlay {
+            background: linear-gradient( to bottom, rgba(250, 250, 250, 0) 95%, rgba(250, 250, 250, 1) 100%);
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            height: 100%;
+            width: 100%;
+            z-index: 10;
+            .media-clear {
+                position: absolute;
+                margin: 0.3em 1em;
+                background: rgb(33, 150, 243) none repeat scroll 0% 0%;
+                padding: 0.3em;
+                right: 1em;
+                width: 24px;
+                min-width: 24px;
+                min-height: 24px;
+                height: 24px;
+            }
+            .media-clear i {
+                width: 24px;
+                font-size: 18px;
+                line-height: 24px;
+                height: 24px;
+            }
+        }
+        img {
+            margin: 1em calc(24px + 16px + 8px) 1em;
+            width: calc(100% - 108px);
+        }
     }
-  }
-
-  @media (min-width: 750px) {
-    & {
-      width: 450px;
+    @media (min-width: 750px) {
+        & {
+            width: 450px;
+        }
     }
-  }
-  @media (min-width: 800px) {
-    & {
-      width: 490px;
+    @media (min-width: 800px) {
+        & {
+            width: 490px;
+        }
     }
-  }
-  @media (min-width: 820px) {
-    & {
-      width: 505px;
+    @media (min-width: 820px) {
+        & {
+            width: 505px;
+        }
     }
-  }
-  @media (min-width: 850px) {
-    & {
-      width: 530px;
+    @media (min-width: 850px) {
+        & {
+            width: 530px;
+        }
     }
-  }
-  @media (min-width: 870px) {
-    & {
-      width: 550px;
+    @media (min-width: 870px) {
+        & {
+            width: 550px;
+        }
     }
-  }
-  @media (min-width: 890px) {
-    & {
-      width: 570px;
+    @media (min-width: 890px) {
+        & {
+            width: 570px;
+        }
     }
-  }
-  @media (min-width: 920px) {
-    & {
-      width: 600px;
+    @media (min-width: 920px) {
+        & {
+            width: 600px;
+        }
     }
-  }
-  @media (min-width: 950px) {
-    & {
-      width: 630px;
+    @media (min-width: 950px) {
+        & {
+            width: 630px;
+        }
     }
-  }
 }
 
 .mdl-textfield {
-  padding: 0px 0;
-  padding-top: 20px;
+    padding: 0px 0;
+    padding-top: 20px;
 }
 
 .mdl-textfield__input {
-  min-height: 2em;
-  transition: height ease-in-out $anim-time;
-  outline: none;
+    min-height: 2em;
+    transition: height ease-in-out $anim-time;
+    outline: none;
 }
 
 .mdl-textfield__label:after {
-  background-color: rgba(0, 0, 0, 0);
-  bottom: 1px;
-  height: 1px;
+    background-color: rgba(0, 0, 0, 0);
+    bottom: 1px;
+    height: 1px;
 }
 
 .send-bar-inner {
-  background: #fafafa;
-  height: 100%;
-  margin: auto;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  border-radius: 16px 16px 0px 0px;
-  box-shadow: -0px -0px 3px rgba(0, 0, 0, 0.15);
-
-  .entry {
-    width: calc(100% - 124px);
-    margin-top: -4px;
-  }
-
-  .send {
-    float: right;
-    margin-top: 8px;
-  }
-
-  .attach-button {
-    float: left;
-    text-align: center;
-    margin-top: 15px;
-    min-width: 0px;
-    width: 28px;
-    height: 28px;
-    opacity: 0.56;
-    margin-right: 8px;
-  }
-
-  .emoji-button {
-    float: left;
-    text-align: center;
-    margin-top: 18px;
-    min-width: 0px;
-    width: 24px;
-    height: 24px;
-    opacity: 0.56;
-    margin-right: 16px;
-  }
+    background: #fafafa;
+    height: 100%;
+    margin: auto;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    border-radius: 16px 16px 0px 0px;
+    box-shadow: -0px -0px 3px rgba(0, 0, 0, 0.15);
+    .entry {
+        width: calc(100% - 124px);
+        margin-top: -4px;
+    }
+    .send {
+        float: right;
+        margin-top: 8px;
+    }
+    .attach-button {
+        float: left;
+        text-align: center;
+        margin-top: 15px;
+        min-width: 0px;
+        width: 28px;
+        height: 28px;
+        opacity: 0.56;
+        margin-right: 8px;
+    }
+    .emoji-button {
+        float: left;
+        text-align: center;
+        margin-top: 18px;
+        min-width: 0px;
+        width: 24px;
+        height: 24px;
+        opacity: 0.56;
+        margin-right: 16px;
+    }
 }
 
 #message-entry {
-  height: 24px;
-  resize: none;
+    height: 24px;
+    resize: none;
 }
 
 #emoji-wrapper {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 10;
-
-  .emoji-mart {
-    z-index: 15;
-    transition: ease-in-out left $anim-time;
-  }
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    .emoji-mart {
+        z-index: 15;
+        transition: ease-in-out left $anim-time;
+    }
 }
 
 body.dark {
-  .preview {
-    background: rgb(32, 32, 36);
-
-    .overlay {
-      background: linear-gradient(
-        to bottom,
-        rgba(32, 32, 36, 0) 95%,
-        rgba(32, 32, 36, 1) 100%
-      );
+    .preview {
+        background: rgb(32, 32, 36);
+        .overlay {
+            background: linear-gradient( to bottom, rgba(32, 32, 36, 0) 95%, rgba(32, 32, 36, 1) 100%);
+        }
     }
-  }
-
-  .send-bar-inner {
-    background: #202024;
-    color: #fff;
-  }
-
-  .mdl-textfield__label {
-    color: #fff !important;
-  }
+    .send-bar-inner {
+        background: #202024;
+        color: #fff;
+    }
+    .mdl-textfield__label {
+        color: #fff !important;
+    }
 }
 
 body.black {
-  .preview {
-    background: rgb(0, 0, 0);
-
-    .overlay {
-      background: linear-gradient(
-        to bottom,
-        rgba(0, 0, 0, 0) 95%,
-        rgba(0, 0, 0, 1) 100%
-      );
+    .preview {
+        background: rgb(0, 0, 0);
+        .overlay {
+            background: linear-gradient( to bottom, rgba(0, 0, 0, 0) 95%, rgba(0, 0, 0, 1) 100%);
+        }
     }
-  }
-
-  .send-bar-inner {
-    background: #000000;
-  }
+    .send-bar-inner {
+        background: #000000;
+    }
 }
 </style>

--- a/src/components/Thread/Sendbar.vue
+++ b/src/components/Thread/Sendbar.vue
@@ -47,10 +47,11 @@
             <div v-show="autocomplete_emoji" id="emoji-autocomplete" :style="emojiAutocompleteStyle">
                 <transition-group name="flip-list" tag="div">
                     <emoji-autocomplete-suggestion
-                        v-for="suggestion in emojiAutocompleteSuggestions"
+                        v-for="(suggestion, i) in emojiAutocompleteSuggestions"
                         :key="suggestion.code"
                         :emoji="suggestion"
                         :on-selected="selectAutocompleteEmoji"
+                        :is-active="i === emojiSelectedIndex"
                     />
                 </transition-group>
             </div>
@@ -61,6 +62,8 @@
                     v-model="message"
                     class="mdl-textfield__input disabled"
                     type="text"
+                    @keydown.down.exact.prevent.stop="onArrowUp"
+                    @keydown.up.exact.prevent.stop="onArrowDown"
                     @keydown.shift.enter.stop
                     @keydown.enter.prevent.stop="dispatchSend"
                 ></textarea>
@@ -120,6 +123,7 @@ export default {
             $wrapper: null,
             $sendbar: null,
             emojiAutocompleteSuggestions: [],
+            emojiSelectedIndex: 0,
         };
     },
 
@@ -156,7 +160,7 @@ export default {
             const lastIndex = cursorContextMessage.length - 1;
             if (lastIndexSemicolon != -1 && lastIndexSemicolon > cursorContextMessage.lastIndexOf(" ") && lastIndexSemicolon != lastIndex) {
                 const emojiSearch = cursorContextMessage.substring(lastIndexSemicolon + 1, lastIndex + 1);
-                this.emojiAutocompleteSuggestions = this.emojiIndex.search(emojiSearch).map((o) => ({ emoji: o.native, code: o.short_name }));
+                this.emojiAutocompleteSuggestions = this.emojiIndex.search(emojiSearch).map((o) => ({ emoji: o.native, code: o.short_name })).slice(0, 10);
             } else {
                 this.emojiAutocompleteSuggestions = [];
             }
@@ -214,7 +218,7 @@ export default {
         dispatchSend(e) { // Dispatch send message when clicked
 
             if (e instanceof KeyboardEvent && this.autocomplete_emoji) {
-                const emoji = this.emojiAutocompleteSuggestions[0].emoji;
+                const emoji = this.emojiAutocompleteSuggestions[this.emojiSelectedIndex].emoji;
                 this.selectAutocompleteEmoji(emoji);
 
                 return;
@@ -387,8 +391,21 @@ export default {
             );
         },
 
+        onArrowDown() {
+            if (this.autocomplete_emoji && this.emojiSelectedIndex > 0) {
+                this.emojiSelectedIndex = this.emojiSelectedIndex - 1;
+            }
+        },
+
+        onArrowUp() {
+            if (this.autocomplete_emoji && this.emojiSelectedIndex < this.emojiAutocompleteSuggestions.length) {
+                this.emojiSelectedIndex = this.emojiSelectedIndex + 1;
+            }
+        },
+
         destroyAutoComplete () {
             this.emojiAutocompleteSuggestions = [];
+            this.emojiSelectedIndex = 0;
         }
     }
 };

--- a/src/components/Thread/Sendbar.vue
+++ b/src/components/Thread/Sendbar.vue
@@ -85,6 +85,16 @@ export default {
         '$route' () { // Update thread on route change
             this.message = "";
             this.removeMedia();
+        },
+
+        'message' () {
+            const lastIndexSemicolon = this.message.lastIndexOf(":");
+            const lastIndex = this.message.length - 1;
+            if (lastIndexSemicolon > this.message.lastIndexOf(" ") && lastIndexSemicolon != lastIndex) {
+                const emojiSearch = this.message.substring(lastIndexSemicolon + 1, lastIndex + 1);
+                const emojiOptions = this.emojiIndex.search(emojiSearch).map((o) => ({ emoji: o.native, title: o.name }));
+                console.log(emojiOptions);
+            }
         }
     },
 
@@ -177,6 +187,7 @@ export default {
             // Clear message
             this.message = "";
         },
+
         /**
          * Removes media from store
          */


### PR DESCRIPTION
When typing into the `Sendbar`, I wanted to show emoji suggestions, the same way that Slack/Github do. You type `:`, then a description of the emoji. For example `:thumbs...`

![Screen Shot 2019-10-11 at 2 08 31 PM](https://user-images.githubusercontent.com/4874287/66678044-9ee67700-ec30-11e9-8a1f-401a2b73554b.png)

Works very well, in my opinion. It grabs results from the `emojiIndex` that we are already building for the emoji picker. As you are typing, it will filter those results. You can use the arrow keys to key through them, or click the emoji. It will also work anywhere in the text field (you can insert the `:` anywhere and it will start to complete, not just the end of the message).

This closes https://github.com/klinker-apps/messenger-issues/issues/925.

Also, VSCode seems to have auto formatted the `Sendbar` file, through the `eslint` plugin, I guess.  🤷‍♂ 