### PR TITLE
Change v-show to v-if for audio and video messages

### DIFF
--- a/src/components/Thread/Message.vue
+++ b/src/components/Thread/Message.vue
@@ -16,8 +16,8 @@
                 </a>
 
                 <!-- Video/Audio -->
-                <video v-show="video_src.length != 0 && !media_loading" controls :src="video_src"></video>
-                <audio v-show="audio_src.length != 0 && !media_loading" controls :src="audio_src"></audio>
+                <video v-if="video_src.length != 0 && !media_loading" controls :src="video_src"></video>
+                <audio v-if="audio_src.length != 0 && !media_loading" controls :src="audio_src"></audio>
             </div>
         </transition>
 


### PR DESCRIPTION
This PR addresses an issue in which messages without video are covered with a speed overlay, making the messages impossible to read. This is caused by the video element on every message. I went ahead and changed the v-show on these to v-if, that way media is still shown properly. 

Before:
![Hard to read text](https://user-images.githubusercontent.com/1274349/68636788-54bc1400-04c2-11ea-9fa3-57e62846f8b7.png)

After: 
![image](https://user-images.githubusercontent.com/1274349/68636858-9947af80-04c2-11ea-885a-427089fe0b92.png)

Example of message with video still rendering correctly:
![image](https://user-images.githubusercontent.com/1274349/68636934-d14ef280-04c2-11ea-87fd-fa718e6d9edf.png)

